### PR TITLE
Unpack coordinates without building a list

### DIFF
--- a/haversine/__init__.py
+++ b/haversine/__init__.py
@@ -21,7 +21,7 @@ def haversine(point1, point2, miles=False):
     lat2, lng2 = point2
 
     # convert all latitudes/longitudes from decimal degrees to radians
-    lat1, lng1, lat2, lng2 = list(map(radians, [lat1, lng1, lat2, lng2]))
+    lat1, lng1, lat2, lng2 = map(radians, (lat1, lng1, lat2, lng2))
 
     # calculate haversine
     lat = lat2 - lat1


### PR DESCRIPTION
Hi,

thanks for putting this haversine function on pypi, it's very handy.
While reading the code I realized there was an unnecessary `list(...)` call on line 24.
On python2, `map` already returns a list, and on python3, the result of `map` is an iterator, so it can be unpacked without building a list.
On my laptop, the function runs 30% faster without building the list.