### PR TITLE
General refactor: use Enum for available units, extract constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Haversine [![Build Status](https://travis-ci.org/mapado/haversine.svg?branch=master)](https://travis-ci.org/mapado/haversine)
 
-Calculate the distance (in km or in miles) between two points on Earth using their latitude and longitude.
+Calculate the distance (in various units) between two points on Earth using their latitude and longitude.
 
 
 ## Example
@@ -8,7 +8,7 @@ Calculate the distance (in km or in miles) between two points on Earth using the
 ### Calculate the distance between Lyon and Paris
 
 ```python
-from haversine import haversine
+from haversine import haversine, Units
 
 lyon = (45.7597, 4.8422) # (lat, lon)
 paris = (48.8567, 2.3508)
@@ -16,11 +16,30 @@ paris = (48.8567, 2.3508)
 haversine(lyon, paris)
 >> 392.2172595594006  # in kilometers
 
+haversine(lyon, paris, unit=Units.MILES)
+>> 243.71201856934454  # in miles
+
+# you can also use the string abbreviation for units:
 haversine(lyon, paris, unit='mi')
 >> 243.71201856934454  # in miles
 
-haversine(lyon, paris, unit='nmi')
+haversine(lyon, paris, unit=Units.NAUTICAL_MILES)
 >> 211.78037755311516  # in nautical miles
+```
+
+The `haversine.Units` enum contains all supported units:
+
+```python
+import haversine
+
+print(tuple(haversine.Units))
+```
+
+outputs
+
+```text
+(<Units.FEET: 'ft'>, <Units.INCHES: 'in'>, <Units.KILOMETERS: 'km'>, 
+ <Units.METERS: 'm'>, <Units.MILES: 'mi'>, <Units.NAUTICAL_MILES: 'nmi'>)
 ```
 
 ## Installation
@@ -30,10 +49,10 @@ $ pip install haversine
 ```
 ## Contributing
 
-Clone the project
+Clone the project.
 
 Install [pipenv](https://github.com/pypa/pipenv).
 
-Run `pipenv install`
+Run `pipenv install --dev`
 
 Launch test with `pipenv run pytest`

--- a/haversine/__init__.py
+++ b/haversine/__init__.py
@@ -1,1 +1,1 @@
-from .haversine import haversine
+from .haversine import Units, haversine

--- a/haversine/haversine.py
+++ b/haversine/haversine.py
@@ -1,7 +1,36 @@
 from math import radians, cos, sin, asin, sqrt
+from enum import Enum
 
 
-def haversine(point1, point2, unit='km'):
+# mean earth radius - https://en.wikipedia.org/wiki/Earth_radius#Mean_radius
+_AVG_EARTH_RADIUS_KM = 6371.0088
+
+
+class Units(Enum):
+    """
+    Enumeration of supported units.
+    The full list can be checked by iterating over the class; e.g.
+    the expression `tuple(Units)`.
+    """
+
+    KILOMETERS = 'km'
+    METERS = 'm'
+    MILES = 'mi'
+    NAUTICAL_MILES = 'nmi'
+    FEET = 'ft'
+    INCHES = 'in'
+
+
+# Units values taken from http://www.unitconversion.org/unit_converter/length.html
+_CONVERSIONS = {Units.KILOMETERS.value:       1.0,
+                Units.METERS.value:           1000.0,
+                Units.MILES.value:            0.621371192,
+                Units.NAUTICAL_MILES.value:   0.539956803,
+                Units.FEET.value:             3280.839895013,
+                Units.INCHES.value:           39370.078740158}
+
+
+def haversine(point1, point2, unit=Units.KILOMETERS):
     """ Calculate the great-circle distance between two points on the Earth surface.
 
     :input: two 2-tuples, containing the latitude and longitude of each point
@@ -21,19 +50,10 @@ def haversine(point1, point2, unit='km'):
     feets (ft) and inches (in).
 
     """
-    # mean earth radius - https://en.wikipedia.org/wiki/Earth_radius#Mean_radius
-    AVG_EARTH_RADIUS_KM = 6371.0088
-
-    # Units values taken from http://www.unitconversion.org/unit_converter/length.html
-    conversions = {'km': 1,
-                   'm': 1000,
-                   'mi': 0.621371192,
-                   'nmi': 0.539956803,
-                   'ft': 3280.839895013,
-                   'in': 39370.078740158}
 
     # get earth radius in required units
-    avg_earth_radius = AVG_EARTH_RADIUS_KM * conversions[unit]
+    unit = unit.value if isinstance(unit, Units) else unit
+    avg_earth_radius = _AVG_EARTH_RADIUS_KM * _CONVERSIONS[unit]
 
     # unpack latitude/longitude
     lat1, lng1 = point1

--- a/haversine/haversine.py
+++ b/haversine/haversine.py
@@ -33,22 +33,25 @@ _CONVERSIONS = {Units.KILOMETERS.value:       1.0,
 def haversine(point1, point2, unit=Units.KILOMETERS):
     """ Calculate the great-circle distance between two points on the Earth surface.
 
-    :input: two 2-tuples, containing the latitude and longitude of each point
-    in decimal degrees.
+    Takes two 2-tuples, containing the latitude and longitude of each point in decimal degrees,
+    and, optionally, a unit of length.
 
-    Keyword arguments:
-    unit -- a string containing the initials of a unit of measurement (i.e. miles = mi)
-            default 'km' (kilometers).
+    :param point1: first point; tuple of (latitude, longitude) in decimal degrees
+    :param point2: second point; tuple of (latitude, longitude) in decimal degrees
+    :param unit: a member of haversine.Units, or, equivalently, a string containing the
+                 initials of its corresponding unit of measurement (i.e. miles = mi)
+                 default 'km' (kilometers).
 
-    Example: haversine((45.7597, 4.8422), (48.8567, 2.3508))
+    Example: ``haversine((45.7597, 4.8422), (48.8567, 2.3508), unit=Units.METERS)``
 
-    :output: Returns the distance between the two points.
+    Precondition: ``unit`` is a supported unit (supported units are listed in the `Units` enum)
+
+    :return: the distance between the two points in the requested unit, as a float.
 
     The default returned unit is kilometers. The default unit can be changed by
-    setting the unit parameter to a string containing the initials of the desired unit.
-    Other available units are miles (mi), nautic miles (nmi), meters (m),
-    feets (ft) and inches (in).
-
+    setting the unit parameter to a member of ``haversine.Units``
+    (e.g. ``haversine.Units.INCHES``), or, equivalently, to a string containing the
+    corresponding abbreviation (e.g. 'in'). All available units can be found in the ``Units`` enum.
     """
 
     # get earth radius in required units

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ setup(
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",
     include_package_data=True,
+    install_requires=['enum34'],
+
     author='Balthazar Rouberol',
     author_email='balthazar@mapado.com',
     maintainer='Julien Deniau',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",
     include_package_data=True,
-    install_requires=['enum34'],
+    install_requires=['enum34;python_version<"3.4"'],
 
     author='Balthazar Rouberol',
     author_email='balthazar@mapado.com',

--- a/tests/test_haversine.py
+++ b/tests/test_haversine.py
@@ -1,22 +1,35 @@
-from haversine import haversine
+from haversine import haversine, Units
 
-lyon = (45.7597, 4.8422)
-paris = (48.8567, 2.3508)
+LYON = (45.7597, 4.8422)
+PARIS = (48.8567, 2.3508)
 
-def test_kilometers():
-    assert haversine(lyon, paris) == 392.2172595594006  # in kilometers
+EXPECTED = {Units.KILOMETERS: 392.2172595594006,
+            Units.METERS: 392217.2595594006,
+            Units.MILES: 243.71250609539814,
+            Units.NAUTICAL_MILES: 211.78037755311516,
+            Units.FEET: 1286802.0326751503,
+            Units.INCHES: 15441624.392102592}
 
-def test_miles():
-    assert haversine(lyon, paris, unit='mi') == 243.71250609539814  # in miles
 
-def test_nautical_miles():
-    assert haversine(lyon, paris, unit='nmi') == 211.78037755311516  # in nautical miles
+def haversine_test_factory(unit):
+    def test():
+        expected = EXPECTED[unit]
+        assert haversine(LYON, PARIS, unit=unit) == expected
+        assert isinstance(unit.value, str)
+        assert haversine(LYON, PARIS, unit=unit.value) == expected
 
-def test_meters():
-    assert haversine(lyon, paris, unit='m') == 392217.2595594006
+    return test
 
-def test_feets():
-    assert haversine(lyon, paris, unit='ft') == 1286802.0326751503
 
-def test_inches():
-    assert haversine(lyon, paris, unit='in') == 15441624.392102592
+test_kilometers = haversine_test_factory(Units.KILOMETERS)
+test_meters = haversine_test_factory(Units.METERS)
+test_miles = haversine_test_factory(Units.MILES)
+test_nautical_miles = haversine_test_factory(Units.NAUTICAL_MILES)
+test_feet = haversine_test_factory(Units.FEET)
+test_inches = haversine_test_factory(Units.INCHES)
+
+
+def test_units_enum():
+    from haversine.haversine import _CONVERSIONS
+    assert all(unit.value in _CONVERSIONS for unit in Units)
+


### PR DESCRIPTION
Made an enumeration for supported units for greater maintainability:

```python
class Units(Enum):
    """
    Enumeration of supported units.
    The full list can be checked by iterating over the class; e.g.
    the expression `tuple(Units)`.
    """

    KILOMETERS = 'km'
    METERS = 'm'
    MILES = 'mi'
    NAUTICAL_MILES = 'nmi'
    FEET = 'ft'
    INCHES = 'in'
```

Updated the documentation and the `setuptools` requirements (`enum34` for Python `< 3.4`) accordingly. The change is fully-backwards compatible (both enum members and the original string abbreviations passed to the `unit` kwarg produce the same result).

Also, constants have been extracted outside the `haversine`  function, to avoid having to re-construct them at each function call.

Finally, tests have been refactored into a common pattern (without changing their behaviour) and a new test for the `Units` enum has been written.