### PR TITLE
Quick fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,19 @@ haversine(lyon, paris, unit=Units.NAUTICAL_MILES)
 >> 211.78037755311516  # in nautical miles
 ```
 
-The `haversine.Units` enum contains all supported units:
+The `haversine.Unit` enum contains all supported units:
 
 ```python
 import haversine
 
-print(tuple(haversine.Units))
+print(tuple(haversine.Unit))
 ```
 
 outputs
 
 ```text
-(<Units.FEET: 'ft'>, <Units.INCHES: 'in'>, <Units.KILOMETERS: 'km'>, 
- <Units.METERS: 'm'>, <Units.MILES: 'mi'>, <Units.NAUTICAL_MILES: 'nmi'>)
+(<Unit.FEET: 'ft'>, <Unit.INCHES: 'in'>, <Unit.KILOMETERS: 'km'>, 
+ <Unit.METERS: 'm'>, <Unit.MILES: 'mi'>, <Unit.NAUTICAL_MILES: 'nmi'>)
 ```
 
 ## Installation

--- a/haversine/__init__.py
+++ b/haversine/__init__.py
@@ -1,1 +1,1 @@
-from .haversine import Units, haversine
+from .haversine import Unit, haversine

--- a/haversine/haversine.py
+++ b/haversine/haversine.py
@@ -22,12 +22,12 @@ class Units(Enum):
 
 
 # Units values taken from http://www.unitconversion.org/unit_converter/length.html
-_CONVERSIONS = {Units.KILOMETERS.value:       1.0,
-                Units.METERS.value:           1000.0,
-                Units.MILES.value:            0.621371192,
-                Units.NAUTICAL_MILES.value:   0.539956803,
-                Units.FEET.value:             3280.839895013,
-                Units.INCHES.value:           39370.078740158}
+_CONVERSIONS = {Units.KILOMETERS:       1.0,
+                Units.METERS:           1000.0,
+                Units.MILES:            0.621371192,
+                Units.NAUTICAL_MILES:   0.539956803,
+                Units.FEET:             3280.839895013,
+                Units.INCHES:           39370.078740158}
 
 
 def haversine(point1, point2, unit=Units.KILOMETERS):
@@ -55,7 +55,7 @@ def haversine(point1, point2, unit=Units.KILOMETERS):
     """
 
     # get earth radius in required units
-    unit = unit.value if isinstance(unit, Units) else unit
+    unit = Units(unit)
     avg_earth_radius = _AVG_EARTH_RADIUS_KM * _CONVERSIONS[unit]
 
     # unpack latitude/longitude

--- a/haversine/haversine.py
+++ b/haversine/haversine.py
@@ -6,11 +6,11 @@ from enum import Enum
 _AVG_EARTH_RADIUS_KM = 6371.0088
 
 
-class Units(Enum):
+class Unit(Enum):
     """
     Enumeration of supported units.
     The full list can be checked by iterating over the class; e.g.
-    the expression `tuple(Units)`.
+    the expression `tuple(Unit)`.
     """
 
     KILOMETERS = 'km'
@@ -21,16 +21,16 @@ class Units(Enum):
     INCHES = 'in'
 
 
-# Units values taken from http://www.unitconversion.org/unit_converter/length.html
-_CONVERSIONS = {Units.KILOMETERS:       1.0,
-                Units.METERS:           1000.0,
-                Units.MILES:            0.621371192,
-                Units.NAUTICAL_MILES:   0.539956803,
-                Units.FEET:             3280.839895013,
-                Units.INCHES:           39370.078740158}
+# Unit values taken from http://www.unitconversion.org/unit_converter/length.html
+_CONVERSIONS = {Unit.KILOMETERS:       1.0,
+                Unit.METERS:           1000.0,
+                Unit.MILES:            0.621371192,
+                Unit.NAUTICAL_MILES:   0.539956803,
+                Unit.FEET:             3280.839895013,
+                Unit.INCHES:           39370.078740158}
 
 
-def haversine(point1, point2, unit=Units.KILOMETERS):
+def haversine(point1, point2, unit=Unit.KILOMETERS):
     """ Calculate the great-circle distance between two points on the Earth surface.
 
     Takes two 2-tuples, containing the latitude and longitude of each point in decimal degrees,
@@ -38,24 +38,24 @@ def haversine(point1, point2, unit=Units.KILOMETERS):
 
     :param point1: first point; tuple of (latitude, longitude) in decimal degrees
     :param point2: second point; tuple of (latitude, longitude) in decimal degrees
-    :param unit: a member of haversine.Units, or, equivalently, a string containing the
+    :param unit: a member of haversine.Unit, or, equivalently, a string containing the
                  initials of its corresponding unit of measurement (i.e. miles = mi)
                  default 'km' (kilometers).
 
-    Example: ``haversine((45.7597, 4.8422), (48.8567, 2.3508), unit=Units.METERS)``
+    Example: ``haversine((45.7597, 4.8422), (48.8567, 2.3508), unit=Unit.METERS)``
 
-    Precondition: ``unit`` is a supported unit (supported units are listed in the `Units` enum)
+    Precondition: ``unit`` is a supported unit (supported units are listed in the `Unit` enum)
 
     :return: the distance between the two points in the requested unit, as a float.
 
     The default returned unit is kilometers. The default unit can be changed by
-    setting the unit parameter to a member of ``haversine.Units``
-    (e.g. ``haversine.Units.INCHES``), or, equivalently, to a string containing the
-    corresponding abbreviation (e.g. 'in'). All available units can be found in the ``Units`` enum.
+    setting the unit parameter to a member of ``haversine.Unit``
+    (e.g. ``haversine.Unit.INCHES``), or, equivalently, to a string containing the
+    corresponding abbreviation (e.g. 'in'). All available units can be found in the ``Unit`` enum.
     """
 
     # get earth radius in required units
-    unit = Units(unit)
+    unit = Unit(unit)
     avg_earth_radius = _AVG_EARTH_RADIUS_KM * _CONVERSIONS[unit]
 
     # unpack latitude/longitude

--- a/tests/test_haversine.py
+++ b/tests/test_haversine.py
@@ -31,5 +31,5 @@ test_inches = haversine_test_factory(Units.INCHES)
 
 def test_units_enum():
     from haversine.haversine import _CONVERSIONS
-    assert all(unit.value in _CONVERSIONS for unit in Units)
+    assert all(unit in _CONVERSIONS for unit in Units)
 

--- a/tests/test_haversine.py
+++ b/tests/test_haversine.py
@@ -1,14 +1,14 @@
-from haversine import haversine, Units
+from haversine import haversine, Unit
 
 LYON = (45.7597, 4.8422)
 PARIS = (48.8567, 2.3508)
 
-EXPECTED = {Units.KILOMETERS: 392.2172595594006,
-            Units.METERS: 392217.2595594006,
-            Units.MILES: 243.71250609539814,
-            Units.NAUTICAL_MILES: 211.78037755311516,
-            Units.FEET: 1286802.0326751503,
-            Units.INCHES: 15441624.392102592}
+EXPECTED = {Unit.KILOMETERS: 392.2172595594006,
+            Unit.METERS: 392217.2595594006,
+            Unit.MILES: 243.71250609539814,
+            Unit.NAUTICAL_MILES: 211.78037755311516,
+            Unit.FEET: 1286802.0326751503,
+            Unit.INCHES: 15441624.392102592}
 
 
 def haversine_test_factory(unit):
@@ -21,15 +21,15 @@ def haversine_test_factory(unit):
     return test
 
 
-test_kilometers = haversine_test_factory(Units.KILOMETERS)
-test_meters = haversine_test_factory(Units.METERS)
-test_miles = haversine_test_factory(Units.MILES)
-test_nautical_miles = haversine_test_factory(Units.NAUTICAL_MILES)
-test_feet = haversine_test_factory(Units.FEET)
-test_inches = haversine_test_factory(Units.INCHES)
+test_kilometers = haversine_test_factory(Unit.KILOMETERS)
+test_meters = haversine_test_factory(Unit.METERS)
+test_miles = haversine_test_factory(Unit.MILES)
+test_nautical_miles = haversine_test_factory(Unit.NAUTICAL_MILES)
+test_feet = haversine_test_factory(Unit.FEET)
+test_inches = haversine_test_factory(Unit.INCHES)
 
 
 def test_units_enum():
     from haversine.haversine import _CONVERSIONS
-    assert all(unit in _CONVERSIONS for unit in Units)
+    assert all(unit in _CONVERSIONS for unit in Unit)
 


### PR DESCRIPTION
Quick improvement left out at #22 . Now the `_CONVERSIONS` dict uses actual `enum` members instead of values. Simplified getting the correct enum member inside the `haversine` function based on the built-in programmatic acces of the `enum` (`enum.__call__`).

Renamed `Units` to `Unit` along the way, to comply with conventions. Now the following more informative error is raised upon using an invalid unit, without any additional exception handling:

```python
haversine(a, b, unit='spam')
```
```text
ValueError: spam is not a valid Unit
```