### PR TITLE
Remove map() call

### DIFF
--- a/haversine/haversine.py
+++ b/haversine/haversine.py
@@ -63,7 +63,10 @@ def haversine(point1, point2, unit=Unit.KILOMETERS):
     lat2, lng2 = point2
 
     # convert all latitudes/longitudes from decimal degrees to radians
-    lat1, lng1, lat2, lng2 = map(radians, (lat1, lng1, lat2, lng2))
+    lat1 = radians(lat1)
+    lng1 = radians(lng1)
+    lat2 = radians(lat2)
+    lng2 = radians(lng2)
 
     # calculate haversine
     lat = lat2 - lat1


### PR DESCRIPTION
Avoid the overhead of constructing the tuple, map object, and deconstructing it:

```
In [1]: from math import radians

In [2]: a = b = c = d = 1.0

In [3]: %timeit ar, br, cr, dr = map(radians, (a, b, c, d))
427 ns ± 1.54 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [4]: %timeit ar = radians(a) ; br = radians(b) ; cr = radians(c) ; dr = radians(d)
271 ns ± 1.79 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

Whilst a micro-optimization, `haversine()` is often called on large data sets so this can lead to an overall large speedup.