### PR TITLE
Add option to return matrix of combinations between two vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ haversine_vector([lyon, london], [paris, new_york], Unit.KILOMETERS)
  	  [6163.43638211 5586.48447423]])
 ```
 The output array from the example above returns the following table:
-|   |Paris|New York
+|   |Paris|New York|
 |---|:---:|:---:|
-Lyon|Lyon <\-> Paris|Lyon <\-> New York
-London|London <\-> Paris|London <\-> New York
+Lyon|Lyon <\-> Paris|Lyon <\-> New York|
+London|London <\-> Paris|London <\-> New York|
 By definition, if you have a vector *a* with _n_ elements, and a vector *b* with _m_ elements. The result matrix *M* would be $n x m$ and a element M\[i,j\] from the matrix would be the distance between the ith coordinate from vector *a* and jth coordinate with vector *b*.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -67,6 +67,28 @@ haversine_vector([lyon, lyon], [paris, new_york], Unit.KILOMETERS)
 
 It is generally slower to use `haversine_vector` to get distance between two points, but can be really fast to compare distances between two vectors.
 
+You can generate a matrix of all combinations between coordinates in different vectors by setting 'comb' parameter as True.
+
+```python
+from haversine import haversine_vector, Unit
+
+lyon = (45.7597, 4.8422) # (lat, lon)
+london = (51.509865, -0.118092)
+paris = (48.8567, 2.3508)
+new_york = (40.7033962, -74.2351462)
+
+haversine_vector([lyon, london], [paris, new_york], Unit.KILOMETERS)
+
+>> array([[ 392.21725956  343.37455271]
+ 	  [6163.43638211 5586.48447423]])
+```
+The output array from the example above returns the following table:
+|   |Paris|New York
+|---|:---:|:---:|
+Lyon|Lyon <\-> Paris|Lyon <\-> New York
+London|London <\-> Paris|London <\-> New York
+By definition, if you have a vector *a* with _n_ elements, and a vector *b* with _m_ elements. The result matrix *M* would be $n x m$ and a element M\[i,j\] from the matrix would be the distance between the ith coordinate from vector *a* and jth coordinate with vector *b*.
+
 ## Contributing
 
 Clone the project.

--- a/README.md
+++ b/README.md
@@ -83,10 +83,12 @@ haversine_vector([lyon, london], [paris, new_york], Unit.KILOMETERS)
  	  [6163.43638211 5586.48447423]])
 ```
 The output array from the example above returns the following table:
+
 |   |Paris|New York|
 |---|:---:|:---:|
-Lyon|Lyon <\-> Paris|Lyon <\-> New York|
-London|London <\-> Paris|London <\-> New York|
+|Lyon|Lyon <\-> Paris|Lyon <\-> New York|
+|London|London <\-> Paris|London <\-> New York|
+
 By definition, if you have a vector *a* with _n_ elements, and a vector *b* with _m_ elements. The result matrix *M* would be $n x m$ and a element M\[i,j\] from the matrix would be the distance between the ith coordinate from vector *a* and jth coordinate with vector *b*.
 
 ## Contributing

--- a/haversine/haversine.py
+++ b/haversine/haversine.py
@@ -75,7 +75,7 @@ def haversine(point1, point2, unit=Unit.KILOMETERS):
     return 2 * get_avg_earth_radius(unit) * asin(sqrt(d))
 
 
-def haversine_vector(array1, array2, unit=Unit.KILOMETERS):
+def haversine_vector(array1, array2, unit=Unit.KILOMETERS, comb=False):
     '''
     The exact same function as "haversine", except that this
     version replaces math functions with numpy functions.
@@ -101,6 +101,11 @@ def haversine_vector(array1, array2, unit=Unit.KILOMETERS):
     if array2.ndim == 1:
         array2 = numpy.expand_dims(array2, 0)
 
+    # Asserts that both arrays have same dimensions if not in combination mode
+    if not comb:
+        if array1.shape != array2.shape:
+            raise IndexError("When not in combination mode, arrays must be of same size. If mode is required, use comb=True as argument.")
+
     # unpack latitude/longitude
     lat1, lng1 = array1[:, 0], array1[:, 1]
     lat2, lng2 = array2[:, 0], array2[:, 1]
@@ -111,6 +116,13 @@ def haversine_vector(array1, array2, unit=Unit.KILOMETERS):
     lat2 = numpy.radians(lat2)
     lng2 = numpy.radians(lng2)
 
+    # If in combination mode, turn coordinates of array1 into column vectors for broadcasting
+    if comb:
+        lat1 = numpy.expand_dims(lat1,axis=0)
+        lng1 = numpy.expand_dims(lng1,axis=0)
+        lat2 = numpy.expand_dims(lat2,axis=1)
+        lng2 = numpy.expand_dims(lng2,axis=1)
+    
     # calculate haversine
     lat = lat2 - lat1
     lng = lng2 - lng1


### PR DESCRIPTION
The intention is to add new functionality in haversine_vector that returns a matrix with the distances between all combinations of coordinates. 

To use this new functionality, the user must set the 'comb' argument to True. And the function will return the above-mentioned matrix instead.

As a bonus, the function will verify the shapes of both input vectors before proceeding if it's usage is with 'comb' as False. If the dimensions differ, the exception message also reminds the user of the new functionality. 

The README file have a detailed description of the new functionality. I've included an example and a mathematical description to make it as clear as possible.

I've used this version in another project of mine and tested on it. Therefore I didn't alter the test files. The results written in README are real and can be used for such.  