### PR TITLE
setup.py: Correct the license assignment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     maintainer_email='julien.deniau@mapado.com',
     url='https://github.com/mapado/haversine',
     packages=['haversine'],
-    license=['MIT'],
+    license='MIT',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
latest python/2.9 + setuptools bail out otherwise

lines = header.split('\n')
| AttributeError: 'list' object has no attribute 'split'

Signed-off-by: Khem Raj <raj.khem@gmail.com>