### PR TITLE
Performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ inverse_haversine(paris, 10, Direction.SOUTH, unit=Unit.NAUTICAL_MILES)
 
 ### Performance optimisation for distances between all points in two vectors
 
-You will need to add [numpy](https://pypi.org/project/numpy/) in order to gain performance with vectors.
+You will need to install [numpy](https://pypi.org/project/numpy/) in order to gain performance with vectors.
+For optimal performance, you can turn off coordinate checking by adding `check=False` and install the optional packages [numba](https://pypi.org/project/numba/) and [icc_rt](https://pypi.org/project/icc_rt/).
 
 You can then do this:
 

--- a/haversine/__init__.py
+++ b/haversine/__init__.py
@@ -1,1 +1,1 @@
-from .haversine import Unit, haversine, haversine_vector, Direction, inverse_haversine
+from .haversine import Unit, haversine, haversine_vector, Direction, inverse_haversine, inverse_haversine_vector

--- a/haversine/haversine.py
+++ b/haversine/haversine.py
@@ -99,9 +99,9 @@ def _ensure_lat_lon_vector(lat: "numpy.ndarray", lon: "numpy.ndarray"):
     """
     Ensure that the given latitude and longitude have proper values. An exception is raised if they are not.
     """
-    if numpy.max(numpy.abs(lat)) > 90:
+    if numpy.abs(lat).max() > 90:
         raise ValueError("Latitude(s) out of range [-90, 90]")
-    if numpy.max(numpy.abs(lon)) > 180:
+    if numpy.abs(lon).max() > 180:
         raise ValueError("Longitude(s) out of range [-180, 180]")
 
 

--- a/haversine/haversine.py
+++ b/haversine/haversine.py
@@ -82,7 +82,7 @@ def _ensure_lat_lon(lat: float, lon: float):
         raise ValueError(f"Longitude {lon} is out of range [-180, 180]")
 
 
-def haversine(point1, point2, unit=Unit.KILOMETERS, normalize=False):
+def haversine(point1, point2, unit=Unit.KILOMETERS, normalize=False, check=True):
     """ Calculate the great-circle distance between two points on the Earth surface.
 
     Takes two 2-tuples, containing the latitude and longitude of each point in decimal degrees,
@@ -94,6 +94,7 @@ def haversine(point1, point2, unit=Unit.KILOMETERS, normalize=False):
                  initials of its corresponding unit of measurement (i.e. miles = mi)
                  default 'km' (kilometers).
     :param normalize: if True, normalize the points to [-90, 90] latitude and [-180, 180] longitude.
+    :param check: if True, check that points are normalized.
 
     Example: ``haversine((45.7597, 4.8422), (48.8567, 2.3508), unit=Unit.METERS)``
 
@@ -115,7 +116,7 @@ def haversine(point1, point2, unit=Unit.KILOMETERS, normalize=False):
     if normalize:
         lat1, lng1 = _normalize(lat1, lng1)
         lat2, lng2 = _normalize(lat2, lng2)
-    else:
+    elif check:
         _ensure_lat_lon(lat1, lng1)
         _ensure_lat_lon(lat2, lng2)
 
@@ -133,7 +134,7 @@ def haversine(point1, point2, unit=Unit.KILOMETERS, normalize=False):
     return 2 * get_avg_earth_radius(unit) * asin(sqrt(d))
 
 
-def haversine_vector(array1, array2, unit=Unit.KILOMETERS, comb=False, normalize=False):
+def haversine_vector(array1, array2, unit=Unit.KILOMETERS, comb=False, normalize=False, check=True):
     '''
     The exact same function as "haversine", except that this
     version replaces math functions with numpy functions.
@@ -169,7 +170,7 @@ def haversine_vector(array1, array2, unit=Unit.KILOMETERS, comb=False, normalize
     if normalize:
         array1 = numpy.array([_normalize(p[0], p[1]) for p in array1])
         array2 = numpy.array([_normalize(p[0], p[1]) for p in array2])
-    else:
+    elif check:
         [_ensure_lat_lon(p[0], p[1]) for p in array1]
         [_ensure_lat_lon(p[0], p[1]) for p in array2]
 

--- a/haversine/haversine.py
+++ b/haversine/haversine.py
@@ -7,7 +7,7 @@ from typing import Union, Tuple
 _AVG_EARTH_RADIUS_KM = 6371.0088
 
 
-class Unit(Enum):
+class Unit(str, Enum):
     """
     Enumeration of supported units.
     The full list can be checked by iterating over the class; e.g.
@@ -24,7 +24,7 @@ class Unit(Enum):
     DEGREES = 'deg'
 
 
-class Direction(Enum):
+class Direction(float, Enum):
     """
     Enumeration of supported directions.
     The full list can be checked by iterating over the class; e.g.
@@ -32,7 +32,7 @@ class Direction(Enum):
     Angles expressed in radians.
     """
 
-    NORTH = 0
+    NORTH = 0.0
     NORTHEAST = pi * 0.25
     EAST = pi * 0.5
     SOUTHEAST = pi * 0.75
@@ -56,7 +56,6 @@ _CONVERSIONS = {
 
 
 def get_avg_earth_radius(unit):
-    unit = Unit(unit)
     return _AVG_EARTH_RADIUS_KM * _CONVERSIONS[unit]
 
 
@@ -206,11 +205,10 @@ def inverse_haversine(point, distance, direction: Union[Direction, float], unit=
     lat, lng = map(radians, (lat, lng))
     d = distance
     r = get_avg_earth_radius(unit)
-    brng = direction.value if isinstance(direction, Direction) else direction
 
     return_lat = asin(sin(lat) * cos(d / r) + cos(lat)
-                      * sin(d / r) * cos(brng))
-    return_lng = lng + atan2(sin(brng) * sin(d / r) *
+                      * sin(d / r) * cos(direction))
+    return_lng = lng + atan2(sin(direction) * sin(d / r) *
                              cos(lat), cos(d / r) - sin(lat) * sin(return_lat))
 
     return_lat, return_lng = map(degrees, (return_lat, return_lng))

--- a/haversine/haversine.py
+++ b/haversine/haversine.py
@@ -117,11 +117,12 @@ def _create_inverse_haversine_kernel(ops):
         """
         lat = ops.radians(lat)
         lng = ops.radians(lng)
-        direction = direction
-        return_lat = asin(ops.sin(lat) * ops.cos(d) + ops.cos(lat)
-                          * ops.sin(d) * ops.cos(direction))
-        return_lng = lng + atan2(ops.sin(direction) * ops.sin(d) *
-                                 ops.cos(lat), ops.cos(d) - ops.sin(lat) * ops.sin(return_lat))
+        cos_d, sin_d = ops.cos(d), ops.sin(d)
+        cos_lat, sin_lat = ops.cos(lat), ops.sin(lat)
+        sin_d_cos_lat = sin_d * cos_lat
+        return_lat = asin(cos_d * sin_lat + sin_d_cos_lat * ops.cos(direction))
+        return_lng = lng + atan2(ops.sin(direction) * sin_d_cos_lat,
+                                 cos_d - sin_lat * ops.sin(return_lat))
         return ops.degrees(return_lat), ops.degrees(return_lng)
     return _inverse_haversine_kernel
 

--- a/haversine/haversine.py
+++ b/haversine/haversine.py
@@ -148,9 +148,9 @@ except ModuleNotFoundError:
 try:
     import numba # type: ignore
     if has_numpy:
-        _haversine_kernel_vector = numba.vectorize(_haversine_kernel)
+        _haversine_kernel_vector = numba.vectorize(fastmath=True)(_haversine_kernel)
         # Tuple output is not supported for numba.vectorize. Just jit the numpy version.
-        _inverse_haversine_kernel_vector = numba.njit(_inverse_haversine_kernel_vector)
+        _inverse_haversine_kernel_vector = numba.njit(fastmath=True)(_inverse_haversine_kernel_vector)
     _haversine_kernel = numba.njit(_haversine_kernel)
     _inverse_haversine_kernel = numba.njit(_inverse_haversine_kernel)
 except ModuleNotFoundError:

--- a/tests/test_inverse_haversine_vector.py
+++ b/tests/test_inverse_haversine_vector.py
@@ -1,0 +1,23 @@
+from haversine import inverse_haversine_vector, Unit, Direction
+from numpy import isclose
+from math import pi
+import pytest
+
+from tests.geo_ressources import LYON, PARIS, NEW_YORK, LONDON
+
+
+@pytest.mark.parametrize(
+    "point, dir, dist, result",
+    [
+        (PARIS, Direction.NORTH, 32, (49.144444, 2.3508)),
+        (PARIS, 0, 32, (49.144444, 2.3508)),
+        (LONDON, Direction.WEST, 50, (51.507778, -0.840556)),
+        (LONDON, pi * 1.5, 50, (51.507778, -0.840556)),
+        (NEW_YORK, Direction.SOUTH, 15, (40.568611, -74.235278)),
+        (NEW_YORK, Direction.NORTHWEST, 50, (41.020556, -74.656667)),
+        (NEW_YORK, pi * 1.25, 50, (40.384722, -74.6525)),
+    ],
+)
+def test_inverse_kilometers(point, dir, dist, result):
+    assert isclose(inverse_haversine_vector([point], [dist], [dir]),
+                   ([result[0]], [result[1]]), rtol=1e-5).all()


### PR DESCRIPTION
Ref #63. This PR is orthogonal to the performance of coordinate checking/normalization, but does add a flag to turn the checking off.

The performance is improved by some minor changes (such as changing the enums to be typed, so that explicit conversions are not needed). But the main change is that if `numba` is installed, the math kernels are jit-compiled.

Additionally, a vectorized version of `inverse_haversine` is added. Just for symmetry.

There is another advantage, which is that the math kernels are written once and generated for either numpy or scalar inputs. Whether that, and the extra performance, is worth the complexity is up to you. If not, the two first commits may still be worthwhile.

The timings below are in nanoseconds per coordinate, with 1000 coordinates per call in the vector variants.

|Version|`haversine`|`haversine_vector`|`inverse_haversine`|`inverse_haversine_vector`|
|---|---|---|---|---|
|**2.5.1** (no check)|703|24|940|—|
|**this** (first two commits: i.e., just enum changes, check=False)|397|24|602|—|
|**this** (check=False)|431|24|434|35|
|**this** (check=False, +numba)|253|12|320|24|
|**this** (check=False, +numba +intel_svml)|244|6|288|19|

Edit: Closes #63 
