### PR TITLE
Adding option to normalize output of inverse_haversine

### DIFF
--- a/haversine/haversine.py
+++ b/haversine/haversine.py
@@ -273,10 +273,14 @@ def haversine_vector(array1, array2, unit=Unit.KILOMETERS, comb=False, normalize
     return get_avg_earth_radius(unit) * _haversine_kernel_vector(lat1, lng1, lat2, lng2)
 
 
-def inverse_haversine(point, distance, direction: Union[Direction, float], unit=Unit.KILOMETERS):
+def inverse_haversine(point, distance, direction: Union[Direction, float], unit=Unit.KILOMETERS, normalize_output=False):
     lat, lng = point
     r = get_avg_earth_radius(unit)
-    return _inverse_haversine_kernel(lat, lng, direction, distance/r)
+    outLat, outLng = _inverse_haversine_kernel(lat, lng, direction, distance / r)
+    if normalize_output:
+        return _normalize(outLat, outLng)
+    else:
+        return (outLat, outLng)
 
 
 def inverse_haversine_vector(array, distance, direction, unit=Unit.KILOMETERS):

--- a/tests/test_inverse_haversine.py
+++ b/tests/test_inverse_haversine.py
@@ -45,3 +45,17 @@ def test_inverse_miles():
 def test_nautical_inverse_miles():
     assert isclose(inverse_haversine(PARIS, 10, Direction.SOUTH,
                    unit=Unit.NAUTICAL_MILES), (48.69014586638915, 2.3508), rtol=1e-5).all()
+
+def test_inverse_normalization():
+    twoDegreesAtEquator = 222390.1
+    # non-breaking behavior without normalization
+    _, pointWestLon = inverse_haversine(
+        (0.0, -179.0), twoDegreesAtEquator, Direction.WEST, Unit.METERS)
+    assert isclose(pointWestLon, -181.0, rtol=1e-5,)
+
+    # behavior with normalization
+    _, pointWestLon = inverse_haversine(
+        (0.0, -179.0), twoDegreesAtEquator, direction=Direction.WEST,
+        unit=Unit.METERS, normalize_output=True,)
+    assert isclose(pointWestLon, 179.0, rtol=1e-5,)
+


### PR DESCRIPTION
### Comportement actuel

In certain cases inverse_haversine would produce points that were invalid, such as -181º.

### Nouveau comportement

In order to avoid breaking changes, the default behavior is as it was, but now there is an option to normalize the output of `inverse_haversine`, such that e.g. -181º would become 179º.

