### PR TITLE
Add more pytest.approx calls

### DIFF
--- a/tests/test_haversine_vector.py
+++ b/tests/test_haversine_vector.py
@@ -11,10 +11,11 @@ from tests.geo_ressources import EXPECTED_LONDON_PARIS, EXPECTED_LYON_NEW_YORK, 
 def test_pair(unit):
     def test_lyon_paris(unit):
         expected_lyon_paris = EXPECTED_LYON_PARIS[unit]
-        assert haversine_vector(LYON, PARIS, unit=unit) == expected_lyon_paris
+        assert haversine_vector(
+            LYON, PARIS, unit=unit) == pytest.approx(expected_lyon_paris)
         assert isinstance(unit.value, str)
         assert haversine_vector(
-            LYON, PARIS, unit=unit.value) == expected_lyon_paris
+            LYON, PARIS, unit=unit.value) == pytest.approx(expected_lyon_paris)
 
     return test_lyon_paris(unit)
 


### PR DESCRIPTION
These tests failed on Debian i386, probably due to x87 excess precision: https://bugs.debian.org/1103116

Fixes: #74